### PR TITLE
Add support of multiport for IPTABLE rules ('{PORTS}' template)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.1.5
+- Add IPtables rule mutliport support (use {PORTS} template)
+
 ### 0.1.4
 - befw now uses stale to get updates faster
 - new paths: $ipset$ for ipsets and $service$ for services

--- a/befw/const.go
+++ b/befw/const.go
@@ -24,8 +24,8 @@ const (
 `
 	iptablesRulesLine         = `
 # {NAME}
--A BEFW -p {PROTO} --dport {PORT} -m set --set {NAME} src -j ACCEPT
--A BEFW -p {PROTO} --dport {PORT} -j DROP
+-A BEFW -p {PROTO} -m multiport --dports {PORTS} -m set --set {NAME} src -j ACCEPT
+-A BEFW -p {PROTO} -m multiport --dports {PORTS} -j DROP
 # /{NAME}
 `
 	iptablesRulesFooter = `

--- a/demo/rules.json
+++ b/demo/rules.json
@@ -1,7 +1,7 @@
 {
   "header": "\n*filter\n:BEFW - [0:0]\n-F BEFW\n-A BEFW -p tcp -m multiport --dports 8300,8301,8302,8500,8501,8600 -j ACCEPT\n",
   "footer": "\nCOMMIT\n",
-  "rule_service": "\n-A BEFW -p {PROTO} --dport {PORT} -m set --match-set {NAME} src -j ACCEPT\n-A BEFW -p {PROTO} --dport {PORT} -j NFLOG --nflog-group 402\n-A BEFW -p {PROTO} --dport {PORT} -j REJECT\n",
+  "rule_service": "\n-A BEFW -p {PROTO} -m multiport --dports {PORTS} -m set --match-set {NAME} src -j ACCEPT\n-A BEFW -p {PROTO} -m multiport --dports {PORTS} -j NFLOG --nflog-group 402\n-A BEFW -p {PROTO} -m multiport --dports {PORTS} -j REJECT\n",
   "rule_allow": "\n-A BEFW -m set --match-set rules_allow src -j ACCEPT\n",
   "rule_deny": "\n-A BEFW -m set --match-set rules_deny src -j DROP\n",
   "static_set": "\n-I BEFW {PRIORITY} -m set --match-set {NAME} src -j {TARGET}\n"

--- a/samples/befw.rules.accept.json
+++ b/samples/befw.rules.accept.json
@@ -1,7 +1,7 @@
 {
   "header": "\n# BEFW IPTABLES RULES @ {DATE}\n*filter\n:BEFW - [0:0]\n-F BEFW\n",
   "footer": "\nCOMMIT\n# /BEFW IPTABLES RULES @ {DATE}\n",
-  "rule_service": "\n# {NAME}\n-A BEFW -p {PROTO} --dport {PORT} -m set --match-set {NAME} src -j ACCEPT\n-A BEFW -p {PROTO} --dport {PORT} -j NFLOG --nflog-group 402\n# / {NAME}\n",
+  "rule_service": "\n# {NAME}\n-A BEFW -p {PROTO} -m multiport --dports {PORTS} -m set --match-set {NAME} src -j ACCEPT\n-A BEFW -p {PROTO} -m multiport --dports {PORTS} -j NFLOG --nflog-group 402\n# / {NAME}\n",
   "rule_allow": "\n-A BEFW -m set --match-set rules_allow src -j ACCEPT\n",
   "rule_deny": "\n-A BEFW -m set --match-set rules_deny src -j DROP\n"
 }

--- a/samples/befw.rules.reject.json
+++ b/samples/befw.rules.reject.json
@@ -2,7 +2,7 @@
 {
   "header": "\n# BEFW IPTABLES RULES @ {DATE}\n*filter\n:BEFW - [0:0]\n-F BEFW\n",
   "footer": "\nCOMMIT\n# /BEFW IPTABLES RULES @ {DATE}\n",
-  "rule_service": "\n# {NAME}\n-A BEFW -p {PROTO} --dport {PORT} -m set --match-set {NAME} src -j ACCEPT\n-A BEFW -p {PROTO} --dport {PORT} -j NFLOG --nflog-group 402\n-A BEFW -p {PROTO} --dport {PORT} -j REJECT\n# / {NAME}\n",
+  "rule_service": "\n# {NAME}\n-A BEFW -p {PROTO} -m multiport --dports {PORTS} -m set --match-set {NAME} src -j ACCEPT\n-A BEFW -p {PROTO} -m multiport --dports {PORTS} -j NFLOG --nflog-group 402\n-A BEFW -p {PROTO} -m multiport --dports {PORTS} -j REJECT\n# / {NAME}\n",
   "rule_allow": "\n-A BEFW -m set --match-set rules_allow src -j ACCEPT\n",
   "rule_deny": "\n-A BEFW -m set --match-set rules_deny src -j DROP\n"
 }


### PR DESCRIPTION
Add support of multiport for IPTABLE rules to reduce separate rules for each port.

Example:
```
- A BEFW -p tcp --dport 443 -m set --set name1_tcp_443  src -j ACCEPT
- A BEFW -p tcp --dport 443 -j NGLOG
- A BEFW -p tcp --dport 443 -j REJECT

- A BEFW -p tcp --dport 80 -m set --set name1_tcp_443  src -j ACCEPT
- A BEFW -p tcp --dport 80 -j NGLOG
- A BEFW -p tcp --dport 80 -j REJECT
```

->

```
- A BEFW -p tcp -m multiport --dports 443,80 -m set --set  name1_tcp_443  src -j ACCEPT
- A BEFW -p tcp -m multiport --dports 443,80 -j NGLOG
- A BEFW -p tcp -m multiport --dports 443,80 -j REJECT
```